### PR TITLE
Crontab 에서도 회원정리나 메일발송을 자동으로 할 수 잇도록 개선

### DIFF
--- a/crontab.php
+++ b/crontab.php
@@ -1,0 +1,9 @@
+<?php
+define('__XE__', true);
+require_once('../../config/config.inc.php'); //XE config.inc.php 주소
+$oContext = &Context::getInstance();
+$oContext->init();
+
+$oMember_expireController = getController('member_expire');
+$output = $oMember_expireController->autoCrontabExpire();
+var_dump($output);

--- a/member_expire.admin.controller.php
+++ b/member_expire.admin.controller.php
@@ -30,6 +30,7 @@ class Member_ExpireAdminController extends Member_Expire
 		$new_config->expire_threshold = $request_vars->expire_threshold;
 		$new_config->expire_method = $request_vars->expire_method;
 		$new_config->auto_expire = $request_vars->auto_expire === 'Y' ? 'Y' : 'N';
+		$new_config->auto_expire_crontab = $request_vars->auto_expire_crontab === 'Y' ? 'Y' : 'N';
 		$new_config->auto_restore = $request_vars->auto_restore === 'Y' ? 'Y' : 'N';
 		$new_config->auto_start = $request_vars->auto_start ? $request_vars->auto_start : date('Y-m-d', time() + zgap());
 		$new_config->email_threshold = $request_vars->auto_notify ? $request_vars->auto_notify : 0;
@@ -50,7 +51,7 @@ class Member_ExpireAdminController extends Member_Expire
 		if ($new_config->email_threshold)
 		{
 			$obj = new stdClass();
-			$obj->threshold = date('YmdHis', time() - ($config->expire_threshold * 86400) + ($new_config->email_threshold * 86400) + zgap());
+			$obj->threshold = date('YmdHis', time() - ($new_config->expire_threshold * 86400) + ($new_config->email_threshold * 86400) + zgap());
 			$unnotified_members_count = executeQuery('member_expire.countUnnotifiedMembers', $obj);
 			$unnotified_members_count = $unnotified_members_count->toBool() ? $unnotified_members_count->data->count : 0;
 			if ($unnotified_members_count > 50)

--- a/member_expire.admin.controller.php
+++ b/member_expire.admin.controller.php
@@ -30,7 +30,7 @@ class Member_ExpireAdminController extends Member_Expire
 		$new_config->expire_threshold = $request_vars->expire_threshold;
 		$new_config->expire_method = $request_vars->expire_method;
 		$new_config->auto_expire = $request_vars->auto_expire === 'Y' ? 'Y' : 'N';
-		$new_config->auto_expire_crontab = $request_vars->auto_expire_crontab === 'Y' ? 'Y' : 'N';
+		$new_config->auto_expire_crontab = $request_vars->auto_expire_crontab === 'crontab' ? 'crontab' : 'N';
 		$new_config->auto_restore = $request_vars->auto_restore === 'Y' ? 'Y' : 'N';
 		$new_config->auto_start = $request_vars->auto_start ? $request_vars->auto_start : date('Y-m-d', time() + zgap());
 		$new_config->email_threshold = $request_vars->auto_notify ? $request_vars->auto_notify : 0;

--- a/member_expire.class.php
+++ b/member_expire.class.php
@@ -32,6 +32,7 @@ class Member_Expire extends ModuleObject
 		if (!$config->expire_threshold) $config->expire_threshold = 365;
 		if (!$config->expire_method) $config->expire_method = 'delete';
 		if (!$config->auto_expire) $config->auto_expire = 'N';
+		if (!$config->auto_expire_crontab) $config->auto_expire_crontab = 'N';
 		if (!$config->auto_restore) $config->auto_restore = 'N';
 		if (!$config->auto_start) $config->auto_start = '2015-08-18';
 		if (!$config->email_threshold) $config->email_threshold = 0;

--- a/member_expire.controller.php
+++ b/member_expire.controller.php
@@ -177,7 +177,97 @@ class Member_ExpireController extends Member_Expire
 			}
 		}
 	}
-	
+
+	/**
+	 * Do not use a login trigger, run crontab every set time.
+	 * @return bool
+	 */
+	public function autoCrontabExpire()
+	{
+		// 자동으로 처리할 일이 없다면 종료한다.
+		$config = $this->getConfig();
+		$tasks = 0;
+		if ($config->auto_expire !== 'Y' && $config->email_threshold <= 0)
+		{
+			return false;
+		}
+
+		// 이번에 처리할 일을 결정한다.
+		$expire_enabled = $config->auto_expire === 'Y' && (time() > (strtotime($config->auto_start) + zgap()));
+		if ($expire_enabled && $config->email_threshold <= 0)
+		{
+			$task = 'expire';
+		}
+		elseif (!$expire_enabled && $config->email_threshold > 0)
+		{
+			$task = 'notify';
+		}
+		else
+		{
+			$task = mt_rand() % 2 ? 'expire' : 'notify';
+		}
+
+		// 휴면계정을 자동 정리한다.
+		if ($task === 'expire')
+		{
+			// 정리할 휴면계정이 있는지 확인한다.
+			$obj = new stdClass();
+			$obj->threshold = date('YmdHis', time() - ($config->expire_threshold * 86400) + zgap());
+			$obj->list_count = $obj->page_count = $obj->page = 1;
+			$obj->orderby = 'asc';
+			$members_query = executeQuery('member_expire.getExpiredMembers', $obj);
+
+			// 정리할 휴면계정이 있다면 지금 정리한다.
+			if ($members_query->toBool() && count($members_query->data))
+			{
+				$oDB = DB::getInstance();
+				$oDB->begin();
+				$oModel = getModel('member_expire');
+
+				foreach ($members_query->data as $member)
+				{
+					if ($config->expire_method === 'delete')
+					{
+						$oModel->deleteMember($member, true, false);
+					}
+					else
+					{
+						$oModel->moveMember($member, true, false);
+					}
+				}
+
+				$oDB->commit();
+			}
+		}
+
+		// 휴면 안내메일을 자동 발송한다.
+		if ($task === 'notify')
+		{
+			// 안내할 회원이 있는지 확인한다.
+			$obj = new stdClass();
+			$obj->threshold = date('YmdHis', time() - ($config->expire_threshold * 86400) + ($config->email_threshold * 86400) + zgap());
+			$obj->list_count = $obj->page_count = $obj->page = 1;
+			$obj->orderby = 'asc';
+			$members_query = executeQuery('member_expire.getUnnotifiedMembers', $obj);
+
+			// 안내할 회원이 있다면 지금 안내메일을 발송한다.
+			if ($members_query->toBool() && count($members_query->data))
+			{
+				$oDB = DB::getInstance();
+				$oDB->begin();
+				$oModel = getModel('member_expire');
+
+				foreach ($members_query->data as $member)
+				{
+					$oModel->sendEmail($member, $config, false, false);
+				}
+
+				$oDB->commit();
+			}
+		}
+		return true;
+	}
+
 	/**
 	 * 모듈 실행 전 트리거.
 	 * 로그인, 아이디/비번찾기 등 휴면계정을 다시 활성화시키기 위해 꼭 필요한 작업을 할 때

--- a/member_expire.controller.php
+++ b/member_expire.controller.php
@@ -184,7 +184,6 @@ class Member_ExpireController extends Member_Expire
 	 */
 	public function autoCrontabExpire()
 	{
-
 		// 자동으로 처리할 일이 없다면 종료한다.
 		$config = $this->getConfig();
 		$tasks = 0;

--- a/member_expire.controller.php
+++ b/member_expire.controller.php
@@ -98,7 +98,7 @@ class Member_ExpireController extends Member_Expire
 		// 자동으로 처리할 일이 없다면 종료한다.
 		$config = $this->getConfig();
 		$tasks = 0;
-		if ($config->auto_expire !== 'Y' && $config->email_threshold <= 0)
+		if ($config->auto_expire !== 'Y' && $config->email_threshold <= 0 || $config->auto_expire_crontab === 'crontab')
 		{
 			return;
 		}
@@ -184,10 +184,11 @@ class Member_ExpireController extends Member_Expire
 	 */
 	public function autoCrontabExpire()
 	{
+
 		// 자동으로 처리할 일이 없다면 종료한다.
 		$config = $this->getConfig();
 		$tasks = 0;
-		if ($config->auto_expire !== 'Y' && $config->email_threshold <= 0)
+		if ($config->auto_expire !== 'Y' && $config->email_threshold <= 0 || $config->auto_expire_crontab !== 'crontab')
 		{
 			return false;
 		}

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -81,7 +81,7 @@
 		<div class="x_control-group">
 			<label class="x_control-label">자동정리 방식</label>
 			<div class="x_controls">
-				<label for="auto_expire_crontab_Y" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_Y" value="Y" checked="checked"|cond="$mex_config->auto_expire_crontab == 'crontab'" /> crontab</label>
+				<label for="auto_expire_crontab_Y" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_Y" value="crontab" checked="checked"|cond="$mex_config->auto_expire_crontab == 'crontab'" /> crontab</label>
 				<label for="auto_expire_crontab_N" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_N" value="N" checked="checked"|cond="$mex_config->auto_expire_crontab != 'crontab'" /> 로그인트리거</label>
 				<p class="x_help-block">자동정리 방법을 설정합니다.<br />
 					회원로그인시 자동으로 정리하거나 혹은 crontab 기능으로 사용할 수 있습니다.</p>

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -77,7 +77,17 @@
 					정리할 계정이 많은 경우 사이트 로딩이 느려지거나 정리가 다소 지연될 수 있습니다.</p>
 			</div>
 		</div>
-		
+
+		<div class="x_control-group">
+			<label class="x_control-label">자동정리 방식</label>
+			<div class="x_controls">
+				<label for="auto_expire_crontab_Y" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_Y" value="Y" checked="checked"|cond="$mex_config->auto_expire_crontab == 'Y'" /> 예</label>
+				<label for="auto_expire_crontab_N" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_N" value="N" checked="checked"|cond="$mex_config->auto_expire_crontab != 'Y'" /> 아니오</label>
+				<p class="x_help-block">자동정리 방법을 설정합니다.<br />
+					회원로그인시 자동으로 정리하거나 혹은 crontab 기능으로 사용할 수 있습니다.</p>
+			</div>
+		</div>
+
 		<div class="x_control-group">
 			<label class="x_control-label">자동 정리 시작일자</label>
 			<div class="x_controls">
@@ -88,7 +98,7 @@
 					오랫동안 로그인하지 않은 회원이라도 안내메일 발송과 동시에 자동 정리되어 버리는 일을 막을 수 있습니다.</p>
 			</div>
 		</div>
-			
+
 		<div class="x_control-group">
 			<label class="x_control-label" for="auto_notify">안내메일 자동 발송</label>
 			<div class="x_controls">

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -81,8 +81,8 @@
 		<div class="x_control-group">
 			<label class="x_control-label">자동정리 방식</label>
 			<div class="x_controls">
-				<label for="auto_expire_crontab_Y" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_Y" value="Y" checked="checked"|cond="$mex_config->auto_expire_crontab == 'Y'" /> 예</label>
-				<label for="auto_expire_crontab_N" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_N" value="N" checked="checked"|cond="$mex_config->auto_expire_crontab != 'Y'" /> 아니오</label>
+				<label for="auto_expire_crontab_Y" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_Y" value="Y" checked="checked"|cond="$mex_config->auto_expire_crontab == 'crontab'" /> crontab</label>
+				<label for="auto_expire_crontab_N" class="x_inline"><input type="radio" name="auto_expire_crontab" id="auto_expire_crontab_N" value="N" checked="checked"|cond="$mex_config->auto_expire_crontab != 'crontab'" /> 로그인트리거</label>
 				<p class="x_help-block">자동정리 방법을 설정합니다.<br />
 					회원로그인시 자동으로 정리하거나 혹은 crontab 기능으로 사용할 수 있습니다.</p>
 			</div>


### PR DESCRIPTION
현재의 방식은 자동으로 트리거를 사용하는 방식인데, 이 방법은 회원의 로그인이 많은 상황에서는 여러번의 실행우려가 있습니다.

회원정리 및 이메일방송 액션중 실행이 완료되지 않은경우 일부 회원의경우 두번의 삭제당함(?)이나 이메일 발송의 우려가 있을 것 같고, 정해진 시간이 아닌 회원이 로그인하는 순간이기 때문에 보통 시간적인 선택지도 없다고 생각합니다.

그래서 개안한 방법으로는 간단하게 PHP파일을 하나를 생성하여 해당 메소드를 실행하도록 구현하는 방법입니다.

해당폴더에 php 파일을 생성한다음, 

```php
<?php
define('__XE__', true);
require_once('../../config/config.inc.php'); //XE config.inc.php 주소
$oContext = &Context::getInstance();
$oContext->init();

$oMember_expireController = getController('member_expire');
$output = $oMember_expireController->autoCrontabExpire();
if($output === true)
{
샬라샬라
}
else
{
샬라샬라
}
```
이렇게 코드를 짜두면, 해당 액션이 있을경우 트리거는 여러번 실행될 우려가 있지만, 이건 클론탭에서 단 한번의 실행으로 원하는 시간(보통 오전 9~12시 사이에 메일발송이 적절)에 발송도 가능하기 때문에 이렇게 한번 만들어보았어요...